### PR TITLE
Correct file.index example code

### DIFF
--- a/configure/file_directives.html
+++ b/configure/file_directives.html
@@ -136,7 +136,7 @@ The sequence of filenames afer search from left to right, and the first file tha
 <dt><a href="configure/syntax_and_structure.html#config_levels">Level</a>:</dt>
 <dd>global, host, path</dd>
 <dt>Default:</dt>
-<dd><code><pre>file.etag: [ &#39;index.html&#39;, &#39;index.htm&#39;, &#39;index.txt&#39; ]</pre></code>
+<dd><code><pre>file.index: [ &#39;index.html&#39;, &#39;index.htm&#39;, &#39;index.txt&#39; ]</pre></code>
 </dl>
 
 <h3 id="file.mime.addtypes" class="directive-title"><a href="configure/file_directives.html#file.mime.addtypes"><code>"file.mime.addtypes"</code></a></h3>


### PR DESCRIPTION
This corrects the example code given for the file.index directive.
